### PR TITLE
respect combined custom date (-d) and classic (-c) output

### DIFF
--- a/src/hodie.c
+++ b/src/hodie.c
@@ -134,8 +134,12 @@ main(int argc, char** argv)
         strncpy(dateval,argv[optind++],16);
     }
 
-    if(custom)
-        parse_date(datetype, dateval, p_ts);
+    if(custom) {
+      parse_date(datetype, dateval, p_ts);
+      if (auc) {
+        p_ts->tm_year=p_ts->tm_year+auc_base;
+      }
+    }
 
     if(hodie_isleap(p_ts->tm_year)==1)
        leap=1;


### PR DESCRIPTION
Previously, using a custom date will cause hodie to ignore classic (AUC) output.

This makes it possible to use classic output together with custom dates.
